### PR TITLE
replace deprecated add-path commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM google/cloud-sdk:latest
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-
+ENV PATH "$PATH:/google-cloud-sdk/bin/gsutil"
+ENV PATH "$PATH:/google-cloud-sdk/bin/gcloud"
 CMD ["version"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,9 +19,6 @@ if [ ! -d "$HOME/.config/gcloud" ]; then
 
 fi
 
-echo ::add-path::/google-cloud-sdk/bin/gcloud
-echo ::add-path::/google-cloud-sdk/bin/gsutil
-
 # Update kubeConfig.
 gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$ZONE_NAME" --project "$PROJECT_ID"
 


### PR DESCRIPTION
set-env and add-path have been deprecated by github and as a result this action no longer works.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

I replaced the add-path method by setting the path in the docker file.
I tested this in my workflows and it runs as before.


Signed-off-by: David O'Dell <davidodell@gmail.com>